### PR TITLE
fix: name build-check step to match branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - run: |
+      - name: build-check
+        run: |
           GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} CGO_ENABLED=0 \
           go build -trimpath -buildvcs=auto -ldflags="-s -w" -o /dev/null ./cmd/craftops


### PR DESCRIPTION
Fixes the branch protection issue where required check 'build-check' doesn't match the actual check names.

This adds an explicit name to the build step so it shows as 'build-check' instead of 'build-check (linux, amd64)' etc.

This will unblock Dependabot PRs #40, #41, #42 which have all checks passing but can't auto-merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration for improved clarity and maintainability. No end-user impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->