### PR TITLE
fix: update Go to 1.25.9 to address stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module craftops
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
Fixes 3 critical vulnerabilities in Go standard library:

- **GO-2026-4947**: Unexpected work during chain building in crypto/x509
- **GO-2026-4946**: Inefficient policy validation in crypto/x509  
- **GO-2026-4870**: Unauthenticated TLS 1.3 KeyUpdate DoS in crypto/tls

All vulnerabilities are fixed in Go 1.25.9.