### PR TITLE
fix: bump Go to 1.25.12 to resolve GO-2026-5856

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module craftops
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
## Summary

The scheduled Security workflow (govulncheck) failed on main (run #29181607793) due to:

- GO-2026-5856 — Encrypted Client Hello privacy leak in crypto/tls
  - Found in: crypto/tls@go1.25.11
  - Fixed in: crypto/tls@go1.25.12

This was introduced by the patch-level Go toolchain pinned via go.mod (go 1.25.11). Bumping to go 1.25.12 resolves the advisory.

## Verification

- go mod tidy succeeds.
- govulncheck ./... reports: No vulnerabilities found.

## Note

The Security workflow only runs on push to main / schedule, so it won't re-run on this PR. After merge, trigger it manually (workflow_dispatch) or wait for the weekly schedule to confirm the alert clears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain version to 1.25.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->